### PR TITLE
call Close() on __delete of connection-sensitive objects

### DIFF
--- a/Lib/DataBaseAbstract.ahk
+++ b/Lib/DataBaseAbstract.ahk
@@ -143,6 +143,10 @@ class DataBase
 	static TRUE := Object()
 	static FALSE := Object()
 	
+	__delete() {
+		this.Close()
+	}
+	
 	IsValid(){
 		throw Exceptions.MustOverride()
 	}
@@ -213,6 +217,10 @@ class DataBase
 class RecordSet
 {
 	_currentRow := 0 	; Row
+	
+	__delete() {
+		this.Close()
+	}
 	
 	MoveNext(){
 		throw Exceptions.MustOverride()


### PR DESCRIPTION
This will eliminate the possibility of connection or resource leaks, and relax the absolute necessity of calling Close() manually.
