### PR TITLE
Implement special enumerators in Row and Table

### DIFF
--- a/Lib/DataBaseAbstract.ahk
+++ b/Lib/DataBaseAbstract.ahk
@@ -80,6 +80,22 @@ class Row
 		this._fields := fields
 		this._columns := columns
 	}
+    
+    __NewEnum() {
+        return new DBA.Row.Enumerator(this)
+    }
+    
+    class Enumerator {
+        __new(row) {
+            this.columnEnum := ObjNewEnum(row.columns)
+            this.fieldEnum := ObjNewEnum(row.fields)
+        }
+        
+        next(ByRef key, ByRef val) {
+            return this.columnEnum.next("", key)
+                && this.fieldEnum.next("",val)
+        }
+    }
 }
 
 /*
@@ -135,6 +151,10 @@ class Table
 		this.Rows := rows
 		this.Columns := columns
 	}
+    
+    __NewEnum() {
+        return ObjNewEnum(this.rows)
+    }
 }
 
 class DataBase


### PR DESCRIPTION
When someone tries to enumerate a table directly (not Table.rows), they
probably mean to enumerate rows. This adds a simple wrapper to do that.

When enumerating a Row, enumerate both the columns and fields Collections
simultaneously, where the first param (key) is the column name, and the
second param (value) is the field's value: `for col_name, value in Row`
