### PR TITLE
Fix performance issue in Collections.Count()

### DIFF
--- a/Lib/Collection.ahk
+++ b/Lib/Collection.ahk
@@ -37,10 +37,7 @@ class Collection
    Returns the count of elements contained in this collection
    */
    Count(){
-      i := 0
-      for e in this ; zählt alle Elemente
-         i++
-      return i
+      return this.SetCapacity(0)
    }
    
    /*


### PR DESCRIPTION
This originally looped through the entire object to get the number of
items. For large objects, this could be a huge performance hit. Instead,
use `this.SetCapacity(0)`, which returns the object's capacity after
shrinking the object to fit. Any performance loss due to shrinking the
object prematurely is gained back exponentially by removing a loop of ahk
code.

Consider:

```
while this.Count() < 1000000
        this.insert(A_Index)
```

This code would loop 500,000,500,000 extra times before this commit.
Insane.
