### PR TITLE
Variable naming and scope corrections

### DIFF
--- a/DBAExampleOOP.ahk
+++ b/DBAExampleOOP.ahk
@@ -15,7 +15,7 @@ Gui, Margin, 10, 10
 
 Gui, Add, Text, x10 w100 h20 0x200 , DB Connection, 
 Gui, Add, ComboBox, x+0 ym w400 vddDatabaseConnection, % connectionStrings
-Gui, Add, DropDownList, yp xp+420 w100 vddDatabaseType, % ArrayToGuiString(DBA.DataBaseFactory.AvaiableTypes, true)
+Gui, Add, DropDownList, yp xp+420 w100 vddDatabaseType, % ArrayToGuiString(DBA.DataBaseFactory.AvailableTypes, true)
 Gui, Add, Button, gReConnect yp xp+140 w80, .connect
 
 Gui, Add, Text, x10 yp+35  w100 h20 0x200 vTX, SQL statement:
@@ -135,9 +135,9 @@ RunSQL(SQL){
 	}
 }
 
-IsEnsureConnection( dialoge=1 ){
+IsEnsureConnection( dialogue=1 ){
 	connected := (currentDB != null)
-	if(dialoge && !connected){
+	if(dialogue && !connected){
 		MsgBox,64, No Connection, You must connect to a DB to use this command.
 	}
 	
@@ -189,7 +189,7 @@ TestBinaryBLob(db){
 	static imagePath := A_scriptdir "\Test\boom.png"
 	
 	if(!IsObject(db))
-		throw Exception("ArgumentExcpetion: db must be a DBA DataBase Object")
+		throw Exception("ArgumentException: db must be a DBA DataBase Object")
 	
 	imgBuffer := MemoryBuffer.CreateFromFile(imagePath)
 	

--- a/Lib/ADO.ahk
+++ b/Lib/ADO.ahk
@@ -6,7 +6,7 @@
 * Provides Static ADO Helper classes and Enums
 *
 */
-class ADO
+class gDBA_ADO
 {
 	class CursorType
 	{

--- a/Lib/ArchLogger.ahk
+++ b/Lib/ArchLogger.ahk
@@ -1,24 +1,24 @@
 #Include <Base>
 
-class ArchLogger
+class gDBA_ArchLogger
 {
 	static Logger := new _ArchLoggerFile()
 	
 	SetLogger(newLogger){
-		ArchLogger.Logger := newLogger
+		gDBA_ArchLogger.Logger := newLogger
 	}
 	
 	Log(msg){
 		date := A_DD "." A_MM "." A_YYYY
 		time := A_Hour ":" A_Min
 		
-		ArchLogger.Logger.Log("# " date " ( " time " ) " msg)
+		gDBA_ArchLogger.Logger.Log("# " date " ( " time " ) " msg)
 	}
 }
 
 class _ArchLoggerCallBack
 {
-	callBack := null
+	callBack := gDBA_null
 	
 	Log(msg){
 		this.callBack.( msg )

--- a/Lib/Base.ahk
+++ b/Lib/Base.ahk
@@ -3,7 +3,7 @@
 ***************************************
 */
 
-global null := 0	; for better readability
+global gDBA_null := 0	; for better readability
 
 /*
 	Check for same (base) Type
@@ -114,7 +114,7 @@ Contains(list, value){
 * Provides some common used Exception Templates
 *
 */
-class Exceptions
+class gDBA_Exceptions
 {
 	NotImplemented(name=""){
 		return Exception("A not implemented Method was called." (name != "" ? ": " name : "") ,-1)

--- a/Lib/Collection.ahk
+++ b/Lib/Collection.ahk
@@ -20,7 +20,7 @@ class Collection
          for each, item in objs
             this.Insert(item)
       } else
-         throw Exceptions.ArgumentException("Must submit Array!")
+         throw gDBA_Exceptions.ArgumentException("Must submit Array!")
    }
    
    Clear(){

--- a/Lib/DataBaseADO.ahk
+++ b/Lib/DataBaseADO.ahk
@@ -5,7 +5,7 @@
 */
 class DataBaseADO extends DBA.DataBase
 {
-	_connection := null
+	_connection := gDBA_null
 	_connectionData := ""
 	
 	__New(connectionString){
@@ -31,7 +31,7 @@ class DataBaseADO extends DBA.DataBase
 		if(this.IsConnected())
 		{
 			this._connection.Close()
-			this._connection := null
+			this._connection := gDBA_null
 		}
 	}
 	
@@ -98,7 +98,7 @@ class DataBaseADO extends DBA.DataBase
 			;Execute( commandtext,ra,options)
 			affectedRows := 0
 			rs := this._connection.Execute(sql, affectedRows)
-			if(IsObject(rs) && rs.State != ADO.ObjectStateEnum.adStateClosed)
+			if(IsObject(rs) && rs.State != gDBA_ADO.ObjectStateEnum.adStateClosed)
 			{
 				ret := this.FetchADORecordSet(rs)
 				rs.Close()
@@ -130,7 +130,7 @@ class DataBaseADO extends DBA.DataBase
 	}
 	
 	FetchADORecordSet(adoRS){
-		tbl := null
+		tbl := gDBA_null
 		if(IsObject(adoRS) && !adoRS.EOF)
 		{
 			columnNames := new Collection()
@@ -167,7 +167,7 @@ class DataBaseADO extends DBA.DataBase
 	
 		rs := ComObjCreate("ADODB.Recordset")
 		/* batch 
-		rs.Open(tableName, this._connection, ADO.CursorType.adOpenKeyset, ADO.LockType.adLockBatchOptimistic, ADO.CommandType.adCmdTable)
+		rs.Open(tableName, this._connection, gDBA_ADO.CursorType.adOpenKeyset, gDBA_ADO.LockType.adLockBatchOptimistic, gDBA_ADO.CommandType.adCmdTable)
 
 		for each, record in records
 		{
@@ -181,7 +181,7 @@ class DataBaseADO extends DBA.DataBase
 		rs.UpdateBatch()
 		*/
 		
-		rs.Open(tableName, this._connection, ADO.CursorType.adOpenKeyset, ADO.LockType.adLockOptimistic, ADO.CommandType.adCmdTable)
+		rs.Open(tableName, this._connection, gDBA_ADO.CursorType.adOpenKeyset, gDBA_ADO.LockType.adLockOptimistic, gDBA_ADO.CommandType.adCmdTable)
 
 		for each, record in records
 		{

--- a/Lib/DataBaseAbstract.ahk
+++ b/Lib/DataBaseAbstract.ahk
@@ -168,11 +168,11 @@ class DataBase
 	}
 	
 	IsValid(){
-		throw Exceptions.MustOverride(this.__Class "." A_ThisFunc)
+		throw gDBA_Exceptions.MustOverride(this.__Class "." A_ThisFunc)
 	}
 	
 	Query(sql){
-		throw Exceptions.MustOverride(this.__Class "." A_ThisFunc)
+		throw gDBA_Exceptions.MustOverride(this.__Class "." A_ThisFunc)
 	}
 	
 	QueryValue(sQry){
@@ -190,7 +190,7 @@ class DataBase
 	}
 	
 	OpenRecordSet(sql, editable = false){
-		throw Exceptions.MustOverride(this.__Class "." A_ThisFunc)
+		throw gDBA_Exceptions.MustOverride(this.__Class "." A_ThisFunc)
 	}
 	
 	ToSqlLiteral(value) {
@@ -206,45 +206,45 @@ class DataBase
 	}
 	
 	EscapeString(string){
-		throw Exceptions.MustOverride(this.__Class "." A_ThisFunc)
+		throw gDBA_Exceptions.MustOverride(this.__Class "." A_ThisFunc)
 	}
 	
 	QuoteIdentifier(identifier){
-		throw Exceptions.MustOverride(this.__Class "." A_ThisFunc)
+		throw gDBA_Exceptions.MustOverride(this.__Class "." A_ThisFunc)
 	}
 	
 	BeginTransaction(){
-		throw Exceptions.MustOverride( this.__Class "." A_ThisFunc)
+		throw gDBA_Exceptions.MustOverride( this.__Class "." A_ThisFunc)
 	}
 	
 	EndTransaction(){
-		throw Exceptions.MustOverride(this.__Class "." A_ThisFunc)
+		throw gDBA_Exceptions.MustOverride(this.__Class "." A_ThisFunc)
 	}
 	
 	Rollback(){
-		throw Exceptions.MustOverride(this.__Class "." A_ThisFunc)
+		throw gDBA_Exceptions.MustOverride(this.__Class "." A_ThisFunc)
 	}
 	
 	Insert(record, tableName){
-		throw Exceptions.MustOverride(this.__Class "." A_ThisFunc)
+		throw gDBA_Exceptions.MustOverride(this.__Class "." A_ThisFunc)
 	}
 	
 	InsertMany(records, tableName){
-		throw Exceptions.MustOverride(this.__Class "." A_ThisFunc)
+		throw gDBA_Exceptions.MustOverride(this.__Class "." A_ThisFunc)
 	}
 	
 	Update(fields, constraints, tableName, safe = True){
-		throw Exceptions.MustOverride(this.__Class "." A_ThisFunc)
+		throw gDBA_Exceptions.MustOverride(this.__Class "." A_ThisFunc)
 	}
 	
 	Close(){
-		throw Exceptions.MustOverride(this.__Class "." A_ThisFunc)
+		throw gDBA_Exceptions.MustOverride(this.__Class "." A_ThisFunc)
 	}
 }
 
 class RecordSet
 {
-	_currentRow := null 	; Row
+	_currentRow := gDBA_null 	; Row
 	
 	__delete() {
 		this.Close()
@@ -255,35 +255,35 @@ class RecordSet
 	}
 	
 	AddNew(){
-		throw Exceptions.MustOverride(this.__Class "." A_ThisFunc)
+		throw gDBA_Exceptions.MustOverride(this.__Class "." A_ThisFunc)
 	}
 	
 	MoveNext(){
-		throw Exceptions.MustOverride(this.__Class "." A_ThisFunc)
+		throw gDBA_Exceptions.MustOverride(this.__Class "." A_ThisFunc)
 	}
 	
 	Delete(){
-		throw Exceptions.MustOverride(this.__Class "." A_ThisFunc)
+		throw gDBA_Exceptions.MustOverride(this.__Class "." A_ThisFunc)
 	}
 	
 	Update(){
-		throw Exceptions.MustOverride(this.__Class "." A_ThisFunc)
+		throw gDBA_Exceptions.MustOverride(this.__Class "." A_ThisFunc)
 	}
 	
 	Close(){
-		throw Exceptions.MustOverride(this.__Class "." A_ThisFunc)
+		throw gDBA_Exceptions.MustOverride(this.__Class "." A_ThisFunc)
 	}
 	
 	getEOF(){
-		throw Exceptions.MustOverride(this.__Class "." A_ThisFunc)
+		throw gDBA_Exceptions.MustOverride(this.__Class "." A_ThisFunc)
 	}
 	
 	IsValid(){
-		throw Exceptions.MustOverride(this.__Class "." A_ThisFunc)
+		throw gDBA_Exceptions.MustOverride(this.__Class "." A_ThisFunc)
 	}
 	
 	getColumnNames(){
-		throw Exceptions.MustOverride(this.__Class "." A_ThisFunc)
+		throw gDBA_Exceptions.MustOverride(this.__Class "." A_ThisFunc)
 	}
 	
 	getCurrentRow(){

--- a/Lib/DataBaseFactory.ahk
+++ b/Lib/DataBaseFactory.ahk
@@ -1,6 +1,6 @@
 class DataBaseFactory
 {
-	static AvaiableTypes := ["SQLite", "MySQL", "ADO"]
+	static AvailableTypes := ["SQLite", "MySQL", "ADO"]
 	
 	/*
 		This static Method returns an Instance of an DataBase derived Object

--- a/Lib/DataBaseSQLLite.ahk
+++ b/Lib/DataBaseSQLLite.ahk
@@ -28,12 +28,12 @@ class DataBaseSQLLite extends DBA.DataBase
 		{
 			throw Exception("Can not create a DataBaseSQLLite instance, because the connection handle is not valid!")
 		}
-		ArchLogger.Log("New DataBaseSQLLite: Handle @" handleDB)
+		gDBA_ArchLogger.Log("New DataBaseSQLLite: Handle @" handleDB)
 	}
 	
 	
 	Close(){
-		;ArchLogger.Log("DataBaseSQLLite: Close DB Handle @" handleDB)
+		;gDBA_ArchLogger.Log("DataBaseSQLLite: Close DB Handle @" handleDB)
 		return SQLite_CloseDB(this._handleDB)
 	}
 	
@@ -98,7 +98,7 @@ class DataBaseSQLLite extends DBA.DataBase
 	*/
 	Query(sql){
 		
-		ret := null
+		ret := gDBA_null
 		
 			if (RegExMatch(sql, "i)^\s*SELECT\s")){ ; check if this is a selection query
 				
@@ -175,7 +175,7 @@ class DataBaseSQLLite extends DBA.DataBase
 		
 		query := SQLite_Query(this._handleDB, sql) ;prepare the query
 		if ErrorLevel
-			msgbox % errorlevel
+			msgbox % ErrorLevel
 		
 		try
 		{

--- a/Lib/RecordSetADO.ahk
+++ b/Lib/RecordSetADO.ahk
@@ -12,7 +12,7 @@ class RecordSetADO extends DBA.RecordSet
 		this._adoRS := ComObjCreate("ADODB.Recordset")
 
 		if(editable)
-			this._adoRS.Open(sql, adoConnection, ADO.CursorType.adOpenKeyset, ADO.LockType.adLockOptimistic, ADO.CommandType.adCmdTable)
+			this._adoRS.Open(sql, adoConnection, gDBA_ADO.CursorType.adOpenKeyset, gDBA_ADO.LockType.adLockOptimistic, gDBA_ADO.CommandType.adCmdTable)
 		else
 			this._adoRS.Open(sql, adoConnection)
 	}
@@ -58,7 +58,7 @@ class RecordSetADO extends DBA.RecordSet
 	Delete(){
 		if(this.IsValid() && !this.getEOF())
 		{
-			this._adoRS.Delete(ADO.AffectEnum.adAffectCurrent)
+			this._adoRS.Delete(gDBA_ADO.AffectEnum.adAffectCurrent)
 		}
 	}
 	
@@ -87,7 +87,7 @@ class RecordSetADO extends DBA.RecordSet
 		if(this.IsValid())
 		{
 			this._adoRS.Close()
-			this._adoRS := null
+			this._adoRS := gDBA_null
 		}
 	}
 	

--- a/Lib/RecordSetSqlLite.ahk
+++ b/Lib/RecordSetSqlLite.ahk
@@ -95,18 +95,18 @@ class RecordSetSqlLite extends DBA.RecordSet
 		Loop, %rc% {
 			ctype := DllCall("SQlite3\sqlite3_column_type", UInt, this._query, Int, A_Index - 1, "Cdecl Int")
 			
-			if (ctype == SQLiteDataType.SQLITE_NULL) {
+			if (ctype == gDBA_SQLiteDataType.SQLITE_NULL) {
 				
 				fields[A_Index] := DBA.DataBase.NULL ;""
 				
-			}else if(ctype == SQLiteDataType.SQLITE_BLOB){
+			}else if(ctype == gDBA_SQLiteDataType.SQLITE_BLOB){
 
 				blobSize := DllCall("SQlite3\sqlite3_column_bytes", UInt, this._query, Int, A_Index -1, "Cdecl UInt")
 				blobPtr := DllCall("SQlite3\sqlite3_column_blob", UInt, this._query, Int, A_Index - 1, "Cdecl Ptr")
 
 				if ( blobPtr )
 				{
-					fields[A_Index] :=  MemoryBuffer.Create( blobPtr, blobSize )
+					fields[A_Index] := MemoryBuffer.Create( blobPtr, blobSize )
 				}else{
 					fields[A_Index] := DBA.DataBase.NULL
 				}

--- a/Lib/SQLite_L.ahk
+++ b/Lib/SQLite_L.ahk
@@ -86,7 +86,7 @@
 #Include <Base>
 #Include <MemoryBuffer>
 
-class SQLiteDataType
+class gDBA_SQLiteDataType
 {
    static SQLITE_INTEGER := 1
    static SQLITE_FLOAT  :=  2
@@ -328,7 +328,7 @@ SQLite_Bind(query, idx, val, type = "auto") {
          type := "text"
    }
    
-   ArchLogger.Log(A_ThisFunc ": Binding value as: " type)
+   gDBA_ArchLogger.Log(A_ThisFunc ": Binding value as: " type)
    
 
    if (type = "int" || type = "Integer")

--- a/Lib/mySQL.ahk
+++ b/Lib/mySQL.ahk
@@ -205,7 +205,7 @@ Mysql_fetch_field(requestResult) {
 Fetches all fields of the resultSet
 */
 MySQL_fetch_fields(requestResult){
-   global MySQL_Field
+   global gDBA_MySQL_Field
    
    fields := []
    fieldCount := MySQL_num_fields(requestResult)
@@ -213,7 +213,7 @@ MySQL_fetch_fields(requestResult){
    Loop, % fieldCount
    {
       fptr := Mysql_fetch_field(requestResult)
-      fields[A_index] := new MySQL_Field(fptr)
+      fields[A_index] := new gDBA_MySQL_Field(fptr)
    }
    return fields
 }
@@ -253,9 +253,6 @@ GetPtrAtAddress(_addr, _offset)
 ;============================================================ 
 __MySQL_Query_Dump(_db, _query)
 {
-   local resultString, result, requestResult, fieldCount
-   local row, lengths, length, fieldPointer, field
-
 
    result := DllCall("libmySQL.dll\mysql_query", "UInt", _db , "AStr", _query)
    
@@ -389,7 +386,7 @@ Public Type API_MYSQL_FIELD
   decimals As Long
 End Type
 */
-class MySQL_Field
+class gDBA_MySQL_Field
 {
    ptr := 0
    


### PR DESCRIPTION
*Fixed spelling of "AvailableTypes" in DBA.DatabaseFactory *BACKWARDS INCOMPATIBLE*
*Renamed some internally used variables and classes to more properly reflect on their global scope (potential for backwards incompatibility)
*Fixed scope of __MySQL_Query_Dump function

I was using this utility in my project and noticed that there were generically-named globals in use that were not part of my project. These were part of DBA. I have made some changes to address these. Please review and let me know what you think.