### PR TITLE
Update DataBaseSQLLite.ahk

### DIFF
--- a/Lib/DataBaseSQLLite.ahk
+++ b/Lib/DataBaseSQLLite.ahk
@@ -166,7 +166,7 @@ class DataBaseSQLLite extends DBA.DataBase
 		{
 			if (columns.HasKey(row.name)){
 				;MsgBox,0,Error,  % "row name found: " row.name "`nTypes: " row.type  ; #DEBUG
-				types[columns[row.name]] := row.types
+				types[columns[row.name]] := row.type
 			}
 		}
 		


### PR DESCRIPTION
If you specify the type of the values, the result is empty. Its a typo.
If you use a not specified records like a big number, what you want to store in text format, can be stored badly, because is out of integer range.